### PR TITLE
fix don't use pager for hosts; it is never that many

### DIFF
--- a/audius/cli/__init__.py
+++ b/audius/cli/__init__.py
@@ -56,8 +56,9 @@ def create_cli(sdk_cls=Audius):
         List available hosts.
         """
 
-        gen = (f"{x}\n" for x in get_hosts())
-        click.echo_via_pager(gen)
+        all_hosts = list(get_hosts())
+        for host in all_hosts:
+            click.echo(host)
 
     cli.add_command(users(sdk_cls))
     cli.add_command(playlists(sdk_cls))

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import find_packages, setup
 extras_require = {
     "test": [
         "pytest>=7.0",
+        "pytest-mock",
     ],
     "lint": [
         "black>=24.10.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,3 +22,16 @@ def test_cli(runner, cli):
 def test_app_name(runner, cli):
     result = runner.invoke(cli, ["config", "app-name"])
     assert result.output == "audius-py\n"
+
+
+def test_hosts(mocker, runner, cli):
+    hosts_patch = mocker.patch("audius.cli.get_hosts")
+    hosts = ["http://host1.example.com", "https://host2.example.com"]
+
+    def patch():
+        yield from hosts
+
+    hosts_patch.side_effect = patch
+
+    result = runner.invoke(cli, "hosts")
+    assert result.output == "\n".join(hosts) + "\n"


### PR DESCRIPTION
### What I did

hosts only returns like 7 things, no pager is necessary.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- \[ \] All changes are completed
- \[ \] New test cases have been added
- \[ \] Documentation has been updated
